### PR TITLE
TeX: ingore lpc files

### DIFF
--- a/Godot.gitignore
+++ b/Godot.gitignore
@@ -1,3 +1,6 @@
+# Godot 4+ specific ignores
+.godot/
+
 # Godot-specific ignores
 .import/
 export.cfg
@@ -9,3 +12,4 @@ export_presets.cfg
 # Mono-specific ignores
 .mono/
 data_*/
+mono_crash.*.json

--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -205,6 +205,7 @@ svg-inkscape/
 sympy-plots-for-*.tex/
 
 # pdfcomment
+*.lpc
 *.upa
 *.upb
 


### PR DESCRIPTION
**Reasons for making this change:**

After compiling a TeX document that uses the pdfcomment package, there was an
auxiliary file with the `.lpc` extension that I have not seen before.

**Links to documentation supporting these rule changes:**

Unfortunately, this auxiliary file is not mentioned in [pdfcomment's documentation](https://mirror.clientvps.com/CTAN/macros/latex/contrib/pdfcomment/doc/pdfcomment.pdf).
